### PR TITLE
fix(database-config) cassandr: update password only on changes

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -322,7 +322,7 @@ func getDatabaseAPIData(d *schema.ResourceData) (map[string]interface{}, error) 
 		if v, ok := d.GetOk("cassandra.0.username"); ok {
 			data["username"] = v.(string)
 		}
-		if v, ok := d.GetOk("cassandra.0.password"); ok {
+		if v, ok := d.GetOk("cassandra.0.password"); ok && d.HasChange("cassandra.0.password") {
 			data["password"] = v.(string)
 		}
 		if v, ok := d.GetOkExists("cassandra.0.tls"); ok {


### PR DESCRIPTION
Do not send the password on updates if it hasn't changed. This is otherwise causing issues with rotated passwords