### PR TITLE
feat(DB/connection): store credentials also in "data" map

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -620,11 +620,17 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 	case "mssql-database-plugin":
 		d.Set("mssql", getConnectionDetailsFromResponse(d, "mssql.0.", resp))
 	case "mysql-database-plugin":
-		d.Set("mysql", getConnectionDetailsFromResponse(d, "mysql.0.", resp))
+		connData := getConnectionDetailsFromResponse(d, "mysql.0.", resp)
+		d.Set("mysql", connData)
+		setCredentialsToData(d, connData)
 	case "mysql-rds-database-plugin":
-		d.Set("mysql_rds", getConnectionDetailsFromResponse(d, "mysql_rds.0.", resp))
+		connData := getConnectionDetailsFromResponse(d, "mysql_rds.0.", resp)
+		d.Set("mysql_rds", connData)
+		setCredentialsToData(d, connData)
 	case "mysql-aurora-database-plugin":
-		d.Set("mysql_aurora", getConnectionDetailsFromResponse(d, "mysql_aurora.0.", resp))
+		connData := getConnectionDetailsFromResponse(d, "mysql_aurora.0.", resp)
+		d.Set("mysql_aurora", connData)
+		setCredentialsToData(d, connData)
 	case "mysql-legacy-database-plugin":
 		d.Set("mysql_legacy", getConnectionDetailsFromResponse(d, "mysql_legacy.0.", resp))
 	case "oracle-database-plugin":
@@ -651,6 +657,17 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 	}
 
 	return nil
+}
+
+func setCredentialsToData(d *schema.ResourceData, connData []map[string]interface{}) {
+	credentials := map[string]interface{}{}
+	if value, ok := connData[0]["username"]; ok {
+		credentials["username"] = value
+	}
+	if value, ok := connData[0]["password"]; ok {
+		credentials["password"] = value
+	}
+	d.Set("data", credentials)
 }
 
 func databaseSecretBackendConnectionUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -252,6 +252,8 @@ func TestAccDatabaseSecretBackendConnectionWithCredentials_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", connURL),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.username", username),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.password", password),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.username", username),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", password),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_open_connections", "2"),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_idle_connections", "0"),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "0"),
@@ -269,6 +271,8 @@ func TestAccDatabaseSecretBackendConnectionWithCredentials_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_rds.0.connection_url", connURL),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_rds.0.username", username),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_rds.0.password", password),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.username", username),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", password),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_rds.0.max_open_connections", "2"),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_rds.0.max_idle_connections", "0"),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_rds.0.max_connection_lifetime", "0"),
@@ -499,9 +503,6 @@ resource "vault_database_secret_backend_connection" "test" {
   mysql {
 	  connection_url = "%s"
 	  max_connection_lifetime = "%d"
-  }
-
-  data = {
 	  password = "%s"
   }
 }


### PR DESCRIPTION
Store SQL connection credentials *also* in the data map, which is used by upstream.

Once the TF state has been updated with this, we can switch to the official provider.